### PR TITLE
Reduce startup grace period

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -63,8 +63,8 @@ variable "zone_id" {
 
 variable "grace_period" {
   type        = number
-  description = "The service startup grace period. Should be high."
-  default     = 840
+  description = "Startup grace period, or the duration of time the application is expected to fail health checks on startup"
+  default     = 30
 }
 
 variable "memory" {


### PR DESCRIPTION
Instruct ECS that NLB health checks should represent the state of the new task after 30 seconds.