### PR TITLE
90s grace

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -64,7 +64,7 @@ variable "zone_id" {
 variable "grace_period" {
   type        = number
   description = "Startup grace period, or the duration of time the application is expected to fail health checks on startup"
-  default     = 30
+  default     = 90
 }
 
 variable "memory" {


### PR DESCRIPTION
https://github.com/cased/terraform-aws-cased-shell-ecs/pull/3 was too aggressive to accommodate a ZeroSSL TLS negotiation. 90s should handle it in most cases.