### PR TITLE
Add support for health check customization

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -227,13 +227,14 @@ resource "aws_lb_target_group" "cased-shell-target-80" {
   }
 
   health_check {
-    healthy_threshold   = "2"
-    unhealthy_threshold = "2"
-    matcher             = "200-399"
-    path                = "/_health"
-    port                = "traffic-port"
-    protocol            = "HTTP"
-    interval            = "30"
+    enabled             = var.health_check_enabled && var.http_health_check_enabled
+    healthy_threshold   = var.health_check_enabled && var.http_health_check_enabled ? try(coalesce(var.http_health_check_healthy_threshold, var.health_check_healthy_threshold), null) : null
+    unhealthy_threshold = var.health_check_enabled && var.http_health_check_enabled ? try(coalesce(var.http_health_check_unhealthy_threshold, var.health_check_unhealthy_threshold), null) : null
+    matcher             = var.health_check_enabled && var.http_health_check_enabled ? try(coalesce(var.http_health_check_matcher, var.health_check_matcher), null) : null
+    path                = var.health_check_enabled && var.http_health_check_enabled ? try(coalesce(var.http_health_check_path, var.health_check_path), null) : null
+    port                = var.health_check_enabled && var.http_health_check_enabled ? try(coalesce(var.http_health_check_port, var.health_check_port), null) : null
+    protocol            = var.health_check_enabled && var.http_health_check_enabled ? try(coalesce(var.http_health_check_protocol, var.health_check_protocol), null) : null
+    interval            = var.health_check_enabled && var.http_health_check_enabled ? try(coalesce(var.http_health_check_interval, var.health_check_interval), null) : null
   }
 
   lifecycle {
@@ -255,13 +256,14 @@ resource "aws_lb_target_group" "cased-shell-target-443" {
   }
 
   health_check {
-    healthy_threshold   = "2"
-    unhealthy_threshold = "2"
-    matcher             = "200-399"
-    path                = "/_health"
-    port                = "traffic-port"
-    protocol            = "HTTPS"
-    interval            = "30"
+    enabled             = var.health_check_enabled && var.https_health_check_enabled
+    healthy_threshold   = var.health_check_enabled && var.https_health_check_enabled ? try(coalesce(var.https_health_check_healthy_threshold, var.health_check_healthy_threshold), null) : null
+    unhealthy_threshold = var.health_check_enabled && var.https_health_check_enabled ? try(coalesce(var.https_health_check_unhealthy_threshold, var.health_check_unhealthy_threshold), null) : null
+    matcher             = var.health_check_enabled && var.https_health_check_enabled ? try(coalesce(var.https_health_check_matcher, var.health_check_matcher), null) : null
+    path                = var.health_check_enabled && var.https_health_check_enabled ? try(coalesce(var.https_health_check_path, var.health_check_path), null) : null
+    port                = var.health_check_enabled && var.https_health_check_enabled ? try(coalesce(var.https_health_check_port, var.health_check_port), null) : null
+    protocol            = var.health_check_enabled && var.https_health_check_enabled ? try(coalesce(var.https_health_check_protocol, var.health_check_protocol), null) : null
+    interval            = var.health_check_enabled && var.https_health_check_enabled ? try(coalesce(var.https_health_check_interval, var.health_check_interval), null) : null
   }
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -90,3 +90,116 @@ variable "log_level" {
   default     = "error"
   description = "Log level"
 }
+
+variable "health_check_enabled" {
+  type    = bool
+  default = true
+}
+
+variable "http_health_check_enabled" {
+  type    = bool
+  default = true
+}
+
+variable "https_health_check_enabled" {
+  type    = bool
+  default = true
+}
+
+variable "health_check_healthy_threshold" {
+  type    = string
+  default = "2"
+}
+
+variable "http_health_check_healthy_threshold" {
+  type    = string
+  default = ""
+}
+
+variable "https_health_check_healthy_threshold" {
+  type    = string
+  default = ""
+}
+variable "health_check_unhealthy_threshold" {
+  type    = string
+  default = "2"
+}
+
+variable "http_health_check_unhealthy_threshold" {
+  type    = string
+  default = ""
+}
+
+variable "https_health_check_unhealthy_threshold" {
+  type    = string
+  default = ""
+}
+variable "health_check_matcher" {
+  type    = string
+  default = ""
+}
+
+variable "http_health_check_matcher" {
+  type    = string
+  default = "200-399"
+}
+
+variable "https_health_check_matcher" {
+  type    = string
+  default = "200-399"
+}
+variable "health_check_path" {
+  type    = string
+  default = "/_health"
+}
+
+variable "http_health_check_path" {
+  type    = string
+  default = ""
+}
+
+variable "https_health_check_path" {
+  type    = string
+  default = ""
+}
+variable "health_check_port" {
+  type    = string
+  default = "traffic-port"
+}
+
+variable "http_health_check_port" {
+  type    = string
+  default = ""
+}
+
+variable "https_health_check_port" {
+  type    = string
+  default = ""
+}
+variable "health_check_protocol" {
+  type    = string
+  default = "TCP"
+}
+
+variable "http_health_check_protocol" {
+  type    = string
+  default = "HTTP"
+}
+
+variable "https_health_check_protocol" {
+  type    = string
+  default = "HTTPS"
+}
+variable "health_check_interval" {
+  type    = string
+  default = "10"
+}
+variable "http_health_check_interval" {
+  type    = string
+  default = ""
+}
+
+variable "https_health_check_interval" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
This PR adds module variables for each of the `health_check` params for the load balancer targets created for Cased Shell's http and https endpoints. For each of the arguments, there's a `health_check_` prefixed version and then `http_health_check_` and `https_health_check_` prefixed ones that can be used to override the defaults.

Subsequent PRs will update the defaults based on the results of some testing and may change the number of customizable variables, so this doesn't necessarily need to go into a release yet.