### PR TITLE
remove matcher customization

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -230,7 +230,6 @@ resource "aws_lb_target_group" "cased-shell-target-80" {
     enabled             = var.health_check_enabled && var.http_health_check_enabled
     healthy_threshold   = var.health_check_enabled && var.http_health_check_enabled ? try(coalesce(var.http_health_check_healthy_threshold, var.health_check_healthy_threshold), null) : null
     unhealthy_threshold = var.health_check_enabled && var.http_health_check_enabled ? try(coalesce(var.http_health_check_unhealthy_threshold, var.health_check_unhealthy_threshold), null) : null
-    matcher             = var.health_check_enabled && var.http_health_check_enabled ? try(coalesce(var.http_health_check_matcher, var.health_check_matcher), null) : null
     path                = var.health_check_enabled && var.http_health_check_enabled ? try(coalesce(var.http_health_check_path, var.health_check_path), null) : null
     port                = var.health_check_enabled && var.http_health_check_enabled ? try(coalesce(var.http_health_check_port, var.health_check_port), null) : null
     protocol            = var.health_check_enabled && var.http_health_check_enabled ? try(coalesce(var.http_health_check_protocol, var.health_check_protocol), null) : null
@@ -259,7 +258,6 @@ resource "aws_lb_target_group" "cased-shell-target-443" {
     enabled             = var.health_check_enabled && var.https_health_check_enabled
     healthy_threshold   = var.health_check_enabled && var.https_health_check_enabled ? try(coalesce(var.https_health_check_healthy_threshold, var.health_check_healthy_threshold), null) : null
     unhealthy_threshold = var.health_check_enabled && var.https_health_check_enabled ? try(coalesce(var.https_health_check_unhealthy_threshold, var.health_check_unhealthy_threshold), null) : null
-    matcher             = var.health_check_enabled && var.https_health_check_enabled ? try(coalesce(var.https_health_check_matcher, var.health_check_matcher), null) : null
     path                = var.health_check_enabled && var.https_health_check_enabled ? try(coalesce(var.https_health_check_path, var.health_check_path), null) : null
     port                = var.health_check_enabled && var.https_health_check_enabled ? try(coalesce(var.https_health_check_port, var.health_check_port), null) : null
     protocol            = var.health_check_enabled && var.https_health_check_enabled ? try(coalesce(var.https_health_check_protocol, var.health_check_protocol), null) : null

--- a/variables.tf
+++ b/variables.tf
@@ -134,20 +134,6 @@ variable "https_health_check_unhealthy_threshold" {
   type    = string
   default = ""
 }
-variable "health_check_matcher" {
-  type    = string
-  default = ""
-}
-
-variable "http_health_check_matcher" {
-  type    = string
-  default = "200-399"
-}
-
-variable "https_health_check_matcher" {
-  type    = string
-  default = "200-399"
-}
 variable "health_check_path" {
   type    = string
   default = "/_health"


### PR DESCRIPTION
Not necessary for our use case and can break TCP configurations.