### PR TITLE
Point http and https health checks at http://localhost:80/_health, add tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: test
+
+on: [push]
+
+jobs:
+  test:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        terraform:
+          - 0.12.30
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: ${{ matrix.terraform }}
+      - name: fmt
+        run: terraform fmt -check
+      - name: test
+        run: ./script/test

--- a/main.tf
+++ b/main.tf
@@ -226,13 +226,19 @@ resource "aws_lb_target_group" "cased-shell-target-80" {
     type    = "lb_cookie"
   }
 
-  health_check {
-    enabled             = var.health_check_enabled && var.http_health_check_enabled
-    healthy_threshold   = var.health_check_enabled && var.http_health_check_enabled ? try(coalesce(var.http_health_check_healthy_threshold, var.health_check_healthy_threshold), null) : null
-    unhealthy_threshold = var.health_check_enabled && var.http_health_check_enabled ? try(coalesce(var.http_health_check_unhealthy_threshold, var.health_check_unhealthy_threshold), null) : null
-    port                = var.health_check_enabled && var.http_health_check_enabled ? try(coalesce(var.http_health_check_port, var.health_check_port), null) : null
-    protocol            = var.health_check_enabled && var.http_health_check_enabled ? try(coalesce(var.http_health_check_protocol, var.health_check_protocol), null) : null
-    interval            = var.health_check_enabled && var.http_health_check_enabled ? try(coalesce(var.http_health_check_interval, var.health_check_interval), null) : null
+  dynamic "health_check" {
+    for_each = var.http_health_check
+
+    content {
+      healthy_threshold   = health_check.value.healthy_threshold
+      interval            = health_check.value.interval
+      matcher             = health_check.value.matcher
+      path                = health_check.value.path
+      port                = health_check.value.port
+      protocol            = health_check.value.protocol
+      timeout             = health_check.value.timeout
+      unhealthy_threshold = health_check.value.unhealthy_threshold
+    }
   }
 
   lifecycle {
@@ -253,13 +259,19 @@ resource "aws_lb_target_group" "cased-shell-target-443" {
     type    = "lb_cookie"
   }
 
-  health_check {
-    enabled             = var.health_check_enabled && var.https_health_check_enabled
-    healthy_threshold   = var.health_check_enabled && var.https_health_check_enabled ? try(coalesce(var.https_health_check_healthy_threshold, var.health_check_healthy_threshold), null) : null
-    unhealthy_threshold = var.health_check_enabled && var.https_health_check_enabled ? try(coalesce(var.https_health_check_unhealthy_threshold, var.health_check_unhealthy_threshold), null) : null
-    port                = var.health_check_enabled && var.https_health_check_enabled ? try(coalesce(var.https_health_check_port, var.health_check_port), null) : null
-    protocol            = var.health_check_enabled && var.https_health_check_enabled ? try(coalesce(var.https_health_check_protocol, var.health_check_protocol), null) : null
-    interval            = var.health_check_enabled && var.https_health_check_enabled ? try(coalesce(var.https_health_check_interval, var.health_check_interval), null) : null
+  dynamic "health_check" {
+    for_each = var.https_health_check
+
+    content {
+      healthy_threshold   = health_check.value.healthy_threshold
+      interval            = health_check.value.interval
+      matcher             = health_check.value.matcher
+      path                = health_check.value.path
+      port                = health_check.value.port
+      protocol            = health_check.value.protocol
+      timeout             = health_check.value.timeout
+      unhealthy_threshold = health_check.value.unhealthy_threshold
+    }
   }
 
   lifecycle {

--- a/script/test
+++ b/script/test
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e -o pipefail
+TERRAFORMS="terraform /usr/local/opt/terraform@0.12/bin/terraform"
+cd test
+
+for version in $TERRAFORMS; do
+    if which $version 2> /dev/null; then
+        if $version init > .terraform/out 2> .terraform/err; then
+            :
+        elif grep required_version .terraform/err; then
+            echo "Skipping..."
+            continue
+        else
+            cat .terraform/err 1>&2
+            exit 1
+        fi
+        $version fmt -recursive -check
+        $version validate
+    fi
+done

--- a/script/test
+++ b/script/test
@@ -5,6 +5,7 @@ cd test
 
 for version in $TERRAFORMS; do
     if which $version 2> /dev/null; then
+        mkdir -p .terraform
         if $version init > .terraform/out 2> .terraform/err; then
             :
         elif grep required_version .terraform/err; then

--- a/test/main.tf
+++ b/test/main.tf
@@ -1,0 +1,68 @@
+
+terraform {
+  required_providers {
+    aws = "~> 2.54"
+  }
+  required_version = ">= 0.12"
+}
+
+provider "aws" {
+  region  = "us-east-1"
+  version = "~> 2.54"
+}
+
+module "test-minimal" {
+  source = "../" # for local dev
+
+  vpc_id                 = "1234"
+  env                    = "test"
+  cluster_id             = "1234"
+  image                  = "casedhub/shell:unstable"
+  security_group_ids     = []
+  container_subnet_ids   = []
+  nlb_subnet_ids         = []
+  cased_shell_secret_arn = ""
+  ssh_username           = "user"
+  log_level              = "debug"
+  hostname               = "test-minimal.example.com"
+  zone_id                = "1234"
+}
+
+module "test-custom-health-check" {
+  source = "../" # for local dev
+
+  vpc_id                 = "1234"
+  env                    = "test"
+  cluster_id             = "1234"
+  image                  = "casedhub/shell:unstable"
+  security_group_ids     = []
+  container_subnet_ids   = []
+  nlb_subnet_ids         = []
+  cased_shell_secret_arn = ""
+  ssh_username           = "user"
+  log_level              = "debug"
+  hostname               = "test-minimal.example.com"
+  zone_id                = "1234"
+
+  http_health_check = [{
+    protocol            = "TCP"
+    port                = "80"
+    path                = null
+    matcher             = null
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    interval            = 30
+    timeout             = 10
+  }]
+
+  https_health_check = [{
+    protocol            = "TCP"
+    port                = "80"
+    path                = null
+    matcher             = null
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    interval            = 30
+    timeout             = 10
+  }]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -91,87 +91,49 @@ variable "log_level" {
   description = "Log level"
 }
 
-variable "health_check_enabled" {
-  type    = bool
-  default = true
+variable "http_health_check" {
+  type = list(object({
+    healthy_threshold   = number
+    interval            = number
+    matcher             = string
+    path                = string
+    port                = number
+    protocol            = string
+    timeout             = number
+    unhealthy_threshold = number
+  }))
+  default = [{
+    protocol            = "HTTP"
+    port                = "80"
+    path                = "/_health"
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    interval            = 30
+    timeout             = 10
+    matcher             = null
+  }]
 }
 
-variable "http_health_check_enabled" {
-  type    = bool
-  default = true
-}
+variable "https_health_check" {
+  type = list(object({
+    healthy_threshold   = number
+    interval            = number
+    matcher             = string
+    path                = string
+    port                = number
+    protocol            = string
+    timeout             = number
+    unhealthy_threshold = number
+  }))
 
-variable "https_health_check_enabled" {
-  type    = bool
-  default = true
-}
-
-variable "health_check_healthy_threshold" {
-  type    = string
-  default = "2"
-}
-
-variable "http_health_check_healthy_threshold" {
-  type    = string
-  default = ""
-}
-
-variable "https_health_check_healthy_threshold" {
-  type    = string
-  default = ""
-}
-variable "health_check_unhealthy_threshold" {
-  type    = string
-  default = "2"
-}
-
-variable "http_health_check_unhealthy_threshold" {
-  type    = string
-  default = ""
-}
-
-variable "https_health_check_unhealthy_threshold" {
-  type    = string
-  default = ""
-}
-variable "health_check_port" {
-  type    = string
-  default = "traffic-port"
-}
-
-variable "http_health_check_port" {
-  type    = string
-  default = ""
-}
-
-variable "https_health_check_port" {
-  type    = string
-  default = ""
-}
-variable "health_check_protocol" {
-  type    = string
-  default = "TCP"
-}
-
-variable "http_health_check_protocol" {
-  type    = string
-  default = "HTTP"
-}
-
-variable "https_health_check_protocol" {
-  type    = string
-  default = "HTTPS"
-}
-variable "health_check_interval" {
-  type    = string
-  default = "10"
-}
-variable "http_health_check_interval" {
-  type    = string
-  default = ""
-}
-
-variable "https_health_check_interval" {
-  type    = string
-  default = ""
+  default = [{
+    protocol            = "HTTP"
+    port                = "80"
+    path                = "/_health"
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    interval            = 30
+    timeout             = 10
+    matcher             = null
+  }]
 }


### PR DESCRIPTION
This PR re-works the configurable health check options to probably support nullable `matcher` and `path` fields when using TCP health checks and adds tests for TCP and HTTP health check scenarios. The default configuration now uses `http://localhost:80/_health` for both HTTP and HTTPS health checks, which will verify that Caddy is completely up and ready.