### PR TITLE
Reduce default health check interval to 5s

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -114,7 +114,7 @@ variable "http_health_check" {
     path                = "/_health"
     healthy_threshold   = 2
     unhealthy_threshold = 2
-    interval            = 30
+    interval            = 5
     timeout             = 30
     matcher             = null
   }]
@@ -138,7 +138,7 @@ variable "https_health_check" {
     path                = "/_health"
     healthy_threshold   = 2
     unhealthy_threshold = 2
-    interval            = 30
+    interval            = 5
     timeout             = 30
     matcher             = null
   }]


### PR DESCRIPTION
HTTP health checks can have an interval between 5s and 30s according to the docs on [CreateTargetGroup](https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html#API_CreateTargetGroup_RequestParameters). This PR sets the default value to 5, which should reduce perceived startup time by 50s.