### PR TITLE
Fewer health check options

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -234,12 +234,11 @@ resource "aws_lb_target_group" "cased-shell-target-80" {
     for_each = var.http_health_check
 
     content {
+      protocol            = "HTTP"
+      interval            = "10"
       healthy_threshold   = health_check.value.healthy_threshold
-      interval            = health_check.value.interval
-      matcher             = health_check.value.matcher
       path                = health_check.value.path
       port                = health_check.value.port
-      protocol            = health_check.value.protocol
       unhealthy_threshold = health_check.value.unhealthy_threshold
     }
   }
@@ -266,12 +265,11 @@ resource "aws_lb_target_group" "cased-shell-target-443" {
     for_each = var.https_health_check
 
     content {
+      protocol            = "HTTP"
+      interval            = "10"
       healthy_threshold   = health_check.value.healthy_threshold
-      interval            = health_check.value.interval
-      matcher             = health_check.value.matcher
       path                = health_check.value.path
       port                = health_check.value.port
-      protocol            = health_check.value.protocol
       unhealthy_threshold = health_check.value.unhealthy_threshold
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -100,46 +100,30 @@ variable "log_level" {
 variable "http_health_check" {
   type = list(object({
     healthy_threshold   = number
-    interval            = number
-    matcher             = string
     path                = string
     port                = number
-    protocol            = string
-    timeout             = number
     unhealthy_threshold = number
   }))
   default = [{
-    protocol            = "HTTP"
     port                = "80"
     path                = "/_health"
     healthy_threshold   = 2
     unhealthy_threshold = 2
-    interval            = 10
-    timeout             = 30
-    matcher             = null
   }]
 }
 
 variable "https_health_check" {
   type = list(object({
     healthy_threshold   = number
-    interval            = number
-    matcher             = string
     path                = string
     port                = number
-    protocol            = string
-    timeout             = number
     unhealthy_threshold = number
   }))
 
   default = [{
-    protocol            = "HTTP"
     port                = "80"
     path                = "/_health"
     healthy_threshold   = 2
     unhealthy_threshold = 2
-    interval            = 10
-    timeout             = 30
-    matcher             = null
   }]
 }


### PR DESCRIPTION
A noop for all correctly configured installs, this PR removes the ability to configure the interval, timeout, and protocol of health checks now that we know what options we'd prefer and how fickle these options are otherwise.