### PR TITLE
Bump minor version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Example
 ```terraform
 module "cased-shell" {
     source  = "cased/terraform-aws-cased-shell-ecs"
-    version = "~> 0.2.0"
+    version = "~> 0.3.0"
 
     # The environment, and the id of the vpc and the cluster where the service will run
     env         = "prod"


### PR DESCRIPTION
Will be merged alongside of https://github.com/cased/terraform-aws-cased-shell-ecs/pull/22 immediately before releasing 0.3.0 so the version in the Terraform registry's docs is correct.