### PR TITLE
Enable Client IP preservation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -232,6 +232,8 @@ resource "aws_lb_target_group" "cased-shell-target-80" {
   protocol             = "TCP"
   vpc_id               = var.vpc_id
   deregistration_delay = "5"
+  preserve_client_ip   = true
+
   stickiness {
     enabled = false
     type    = "lb_cookie"
@@ -262,6 +264,7 @@ resource "aws_lb_target_group" "cased-shell-target-443" {
   protocol             = "TCP"
   vpc_id               = var.vpc_id
   deregistration_delay = "10"
+  preserve_client_ip   = true
 
   stickiness {
     enabled = false

--- a/test/main.tf
+++ b/test/main.tf
@@ -1,14 +1,14 @@
 
 terraform {
   required_providers {
-    aws = "~> 2.54"
+    aws = "~> 3.35"
   }
   required_version = ">= 0.12"
 }
 
 provider "aws" {
   region  = "us-east-1"
-  version = "~> 2.54"
+  version = "~> 3.35"
 }
 
 module "test-minimal" {


### PR DESCRIPTION
Enables https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#client-ip-preservation on load balancer target groups.