### PR TITLE
Set minimum required version of AWS provider

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -3,12 +3,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.35 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,8 @@
 terraform {
   required_version = ">= 0.12"
+  required_providers {
+    aws = "~> 3.35"
+  }
 }
 
 

--- a/test/main.tf
+++ b/test/main.tf
@@ -1,7 +1,7 @@
 
 terraform {
   required_providers {
-    aws = "~> 3.35"
+    aws = ">= 3.35"
   }
   required_version = ">= 0.12"
 }


### PR DESCRIPTION
This PR sets the minimum version of the AWS provider required to get the functionality necessary for https://github.com/cased/terraform-aws-cased-shell-ecs/pull/26. With this change, users who need to upgrade their AWS provider will get an error message about the required plugin version constraint like the following instead of the current confusing error message about unexpected arguments:

```
No provider "aws" plugins meet the constraint ">= 2.70,>= 3.35,~> 2.54".
```

I'll release this as 0.3.3.